### PR TITLE
Workaround of ML2018 INPUT() bug

### DIFF
--- a/clusterCaSim/host/START_Simulation.m
+++ b/clusterCaSim/host/START_Simulation.m
@@ -42,7 +42,10 @@ function START_Simulation()
     
     % Loop until user inputs correct data
     while true
-        reply = input(hint, 's');
+        % MATLAB 2018a has a bug and may not show prompt passed to input() function
+        % so the prompt has to be printed separately
+        fprintf(hint);
+        reply = input('', 's');
         if strcmp(reply, '1') || strcmp(reply, '2')
             fprintf('\n');
             break


### PR DESCRIPTION
Workaround of MATLAB 2018 bug relate to INPUT() function: the function may not show prompt passed as argument